### PR TITLE
Enable NFS Mount

### DIFF
--- a/net/nfs.c
+++ b/net/nfs.c
@@ -683,7 +683,7 @@ static void nfs_handler(uchar *pkt, unsigned dest, struct in_addr sip,
 			if (!rlen)
 				nfs_download_state = NETLOOP_SUCCESS;
 			nfs_state = STATE_UMOUNT_REQ;
-			nfs_send();
+			//nfs_send();
 		}
 		break;
 	}


### PR DESCRIPTION
Dear swarren.

NFS boot doesn't work on raspberry pi model b+ by a problem of unmounting. The easiest and ugly solution is to skip umount. It seems that there are some problem with recent changes in net/net.c. Please check them. 

Thank.
